### PR TITLE
projects: add offline-first smart energy monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ You can usually find community members (including some employees of Espressif) i
 - [esp-clock](https://github.com/playfulFence/esp-clock) - Clock with environment stats. [Wokwi project](https://wokwi.com/projects/342312626601067091)
 - [esp32c3-rust-std-temperature-logger](https://github.com/bjoernQ/esp32c3-rust-std-temperature-logger) - MQTT temperature logger running on ESP32-C3.
 - [mch2022-rust-app](https://github.com/p2mate/mch2022-rust-app) - Example that shows a nice rust screensaver in MCH2022 badge.
+- [OFMon](https://github.com/arashsm79/OFMon) - Offline-first smart energy monitor using littlefs, Rust, ESP32, and Thingsboard. [See details](https://moslehian.com/posts/2022/3-ofmon/).
 - [rust-esp32-std-demo](https://github.com/ivmarkov/rust-esp32-std-demo) - A demo `std` binary crate for the ESP32[XX] and [ESP-IDF](https://github.com/espressif/esp-idf), which connects to WiFi, Ethernet, drives a small HTTP server and draws on a LED screen.
 - [rust4mch](https://github.com/jhaand/rust4mch) - Example to run Rust code on the MCH2022 badge.
 - [rustzx-esp32](https://github.com/georgik/rustzx-esp32) - ZX Spectrum emulator based on RustZX project.


### PR DESCRIPTION
Offline-first smart energy monitoring platform using Rust, ESP32, and Thingsboard. Supports OTA updates and uses [littlefs](https://github.com/littlefs-project/littlefs) as its filesystem through [esp-littlefs](https://github.com/joltwallet/esp_littlefs). 