### PR TITLE
projects: add ESP32-S3 Box graphic examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ You can usually find community members (including some employees of Espressif) i
 - [ps2keyboard-esp32c3](https://github.com/bjoernQ/ps2keyboard-esp32c3) - PS/2 keyboard implementation for ESP32-C3.
 - [esp32c3-ota-experiment](https://github.com/bjoernQ/esp32c3-ota-experiment) - ESP32-C3 Bare Metal OTA Experiment.
 - [SlimeVR-Rust/firmware](https://github.com/SlimeVR/SlimeVR-Rust/tree/main/firmware) - Async & no_std rust firmware for SlimeVR Full Body Tracking.
+- [esp32s3-box-examples](https://github.com/sambenko/esp32s3-box-examples) - Various graphic examples for ESP32-S3 Box.
 
 ## License
 


### PR DESCRIPTION
This project consists of various graphic examples for ESP32-S3 Box. It is my initial project and it uses the device in a bit different way.

Can be used as a baseline for demos for tech fairs, Rust events, etc.