### PR TITLE
Add gateway-rs project

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ You can usually find community members (including some employees of Espressif) i
 - [bluedroid](https://github.com/pulse-loop/bluedroid) - Safe wrapper for the Bluedroid Bluetooth stack.
 - [esp-clock](https://github.com/playfulFence/esp-clock) - Clock with environment stats. [Wokwi project](https://wokwi.com/projects/342312626601067091)
 - [esp32c3-rust-std-temperature-logger](https://github.com/bjoernQ/esp32c3-rust-std-temperature-logger) - MQTT temperature logger running on ESP32-C3.
+- [gateway-rs](https://github.com/OpenIoTHub/gateway-rs) - A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet(like [frp](https://github.com/fatedier/frp) but running on ESP32).
 - [mch2022-rust-app](https://github.com/p2mate/mch2022-rust-app) - Example that shows a nice rust screensaver in MCH2022 badge.
 - [OFMon](https://github.com/arashsm79/OFMon) - Offline-first smart energy monitor using littlefs, Rust, ESP32, and Thingsboard. [See details](https://moslehian.com/posts/2022/3-ofmon/).
 - [rust-esp32-std-demo](https://github.com/ivmarkov/rust-esp32-std-demo) - A demo `std` binary crate for the ESP32[XX] and [ESP-IDF](https://github.com/espressif/esp-idf), which connects to WiFi, Ethernet, drives a small HTTP server and draws on a LED screen.


### PR DESCRIPTION
A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet.